### PR TITLE
Back and up navigation in form containers

### DIFF
--- a/app/src/main/java/org/givingkitchen/android/MainActivity.kt
+++ b/app/src/main/java/org/givingkitchen/android/MainActivity.kt
@@ -2,10 +2,24 @@ package org.givingkitchen.android
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import androidx.navigation.fragment.NavHostFragment
+import org.givingkitchen.android.util.FragmentBackPressedListener
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+    }
+
+    override fun onBackPressed() {
+        // Check if currently visible fragment wants to override the back press
+        val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as? NavHostFragment
+        val currentFragment = navHostFragment?.childFragmentManager?.primaryNavigationFragment as? FragmentBackPressedListener
+        currentFragment?.let {
+            if (currentFragment.onBackPressed()) {
+                return
+            }
+        }
+        super.onBackPressed()
     }
 }

--- a/app/src/main/java/org/givingkitchen/android/ui/forms/QuestionsContainerFragment.kt
+++ b/app/src/main/java/org/givingkitchen/android/ui/forms/QuestionsContainerFragment.kt
@@ -12,6 +12,7 @@ import android.support.v4.view.ViewPager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import androidx.navigation.fragment.findNavController
 import kotlinx.android.synthetic.main.fragment_questions_container.*
 import org.givingkitchen.android.R
@@ -106,6 +107,14 @@ class QuestionsContainerFragment: Fragment(), FragmentBackPressedListener {
     private fun moveToPreviousQuestion() {
         viewPager_questionsContainer.setCurrentItem(viewPager_questionsContainer.currentItem - 1, true)
     }
+
+    private fun hideKeyboardIfShowing() {
+        val view = activity?.currentFocus
+        view?.let {
+            val imm = context!!.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+            imm?.let { it.hideSoftInputFromWindow(view.windowToken, 0) }
+        }
+    }
     
     private val backButtonClickListener = View.OnClickListener {
         if (!onBackPressed()) {
@@ -114,6 +123,7 @@ class QuestionsContainerFragment: Fragment(), FragmentBackPressedListener {
     }
 
     private val nextButtonClickListener = View.OnClickListener {
+        hideKeyboardIfShowing()
         val currentItem = viewPager_questionsContainer.currentItem
         for (answer in questionPages[currentItem].getQuestionsAndAnswers()) {
             // todo: store these questions and answers in Room instead of shared prefs
@@ -129,7 +139,7 @@ class QuestionsContainerFragment: Fragment(), FragmentBackPressedListener {
     }
 
     private val submitButtonClickListener = View.OnClickListener {
-        // todo: make the keyboard disappear when submit or next is pressed
+        hideKeyboardIfShowing()
         var firstUnansweredPage: Int? = null
 
         for (i in 0 until questionPages.size) {

--- a/app/src/main/java/org/givingkitchen/android/ui/forms/prologue/FormPrologueFragment.kt
+++ b/app/src/main/java/org/givingkitchen/android/ui/forms/prologue/FormPrologueFragment.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.navigation.Navigation
+import androidx.navigation.fragment.findNavController
 import com.squareup.moshi.JsonAdapter
 import kotlinx.android.synthetic.main.fragment_form_prologue.*
 import org.givingkitchen.android.R
@@ -36,7 +37,6 @@ class FormPrologueFragment : Fragment() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // todo: set cancel button action
         super.onCreate(savedInstanceState)
         jsonAdapter = Services.moshi.adapter(Form::class.java)
         model = ViewModelProviders.of(this).get(FormPrologueViewModel::class.java)
@@ -132,6 +132,6 @@ class FormPrologueFragment : Fragment() {
     }
 
     private val cancelClickListener = View.OnClickListener {
-        Toast.makeText(context, "cancel button clicked", Toast.LENGTH_SHORT).show()
+        findNavController().navigateUp()
     }
 }

--- a/app/src/main/java/org/givingkitchen/android/ui/forms/prologue/FormPrologueFragment.kt
+++ b/app/src/main/java/org/givingkitchen/android/ui/forms/prologue/FormPrologueFragment.kt
@@ -40,13 +40,6 @@ class FormPrologueFragment : Fragment() {
         super.onCreate(savedInstanceState)
         jsonAdapter = Services.moshi.adapter(Form::class.java)
         model = ViewModelProviders.of(this).get(FormPrologueViewModel::class.java)
-        model.getCurrentJson().observe(this, Observer<Form> { liveData ->
-            updateJson(liveData!!)
-        })
-        model.isProgressBarVisible().observe(this, Observer<Boolean> { liveData ->
-            updateProgressBarVisibility(liveData!!)
-        })
-        getData()
     }
 
     @Nullable
@@ -57,6 +50,14 @@ class FormPrologueFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        model.getCurrentJson().observe(this, Observer<Form> { liveData ->
+            updateJson(liveData!!)
+        })
+        model.isProgressBarVisible().observe(this, Observer<Boolean> { liveData ->
+            updateProgressBarVisibility(liveData!!)
+        })
+        getData()
+
         shareButton_formsPrologue.setOnClickListener(shareClickListener)
         cancel_formsPrologue.setOnClickListener(cancelClickListener)
         startButton_formsPrologue.setOnClickListener(startButtonClickListener)

--- a/app/src/main/java/org/givingkitchen/android/ui/homescreen/about/feedback/FeedbackFragment.kt
+++ b/app/src/main/java/org/givingkitchen/android/ui/homescreen/about/feedback/FeedbackFragment.kt
@@ -6,6 +6,7 @@ import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.navigation.fragment.findNavController
 import kotlinx.android.synthetic.main.fragment_feedback.*
 import org.givingkitchen.android.R
 
@@ -22,13 +23,18 @@ class FeedbackFragment: Fragment()  {
         submit_feedbackScreen.setOnClickListener(submitButtonClickListener)
     }
 
+    private fun navigateUp() {
+        findNavController().navigateUp()
+    }
+
     private val upButtonClickListener = View.OnClickListener {
-        // todo: put an onBackPressed() call here
+        navigateUp()
     }
 
     private val submitButtonClickListener = View.OnClickListener {
         // todo: actually submit the feedback
         val a = SubmitFeedbackDialogFragment()
+        a.setOnCompleteListener { navigateUp() }
         a.show(fragmentManager, "Feedback_Submit_Success")
     }
 }

--- a/app/src/main/java/org/givingkitchen/android/ui/homescreen/about/feedback/SubmitFeedbackDialogFragment.kt
+++ b/app/src/main/java/org/givingkitchen/android/ui/homescreen/about/feedback/SubmitFeedbackDialogFragment.kt
@@ -9,18 +9,22 @@ import org.givingkitchen.android.R
 
 class SubmitFeedbackDialogFragment : AppCompatDialogFragment() {
 
+    private var onComplete: ((Boolean) -> Unit)? = null
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return activity?.let {
             val builder = AlertDialog.Builder(it)
             builder.setMessage(R.string.feedback_dialog_description)
                     .setTitle(R.string.feedback_dialog_header)
-                    .setPositiveButton(R.string.feedback_dialog_button,
-                            // todo: make FeedbackFragment call onBackPressed upon dismissing this dialog
-                            DialogInterface.OnClickListener { dialog, id ->
-
-                            })
+                    .setPositiveButton(R.string.feedback_dialog_button) { _, _ ->
+                        onComplete?.invoke(true)
+                    }
 
             builder.create()
         } ?: throw IllegalStateException("Activity cannot be null")
+    }
+
+    fun setOnCompleteListener(onComplete: (Boolean) -> Unit) {
+        this.onComplete = onComplete
     }
 }


### PR DESCRIPTION
- Adds support for device back button handling in a form/question container
- Adds up navigation in back/cancel buttons in toolbar in form/question containers
- Reloads form prologue data in `onViewCreated` so that screen isn't empty when reopening through a back press